### PR TITLE
Fix bug on limited number of repositiories found

### DIFF
--- a/python/starring_them_all.py
+++ b/python/starring_them_all.py
@@ -13,9 +13,13 @@ for org_name in org_names:
         'Accept': 'application/vnd.github.v3+json'
     }
 
-    response = requests.get(org_repos_url, headers=headers)
+    response = requests.get(org_repos_url, headers=headers, params={'per_page': 100})
+    print(f'Found {len(response.json())} repositories in {org_name}')
+
     if response.status_code == 200:
         repos = response.json()
         # Star each repository in the organization
         for repo in repos:
             subprocess.run(['gh', 'api' ,'--method', 'PUT', '-H', 'Accept: application/vnd.github+json', '-H', 'X-GitHub-Api-Version: 2022-11-28', f'/user/starred/{org_name}/{repo["name"]}'])
+
+print('All repositories starred! ⭐️')


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
We like to have a script that stars the repos for us... and also works.

**What does this PR do?**
The [GitHub REST API](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28) would only return max 30 repos if we do not specify otherwise.
As indicated, I added the `per_page` parameter and set it to 100. If we go over 100 repos per org we would need to introduce the logic of making multiple requests for each page.

## References
See the docs linked above

## How has this PR been tested?
Tested locally checking on packages on Brainglobe I noticed were not starred.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
