### PR TITLE
Bash script to compare cellfinder PR to main

### DIFF
--- a/bash/compare_cellfinder_output.sh
+++ b/bash/compare_cellfinder_output.sh
@@ -59,6 +59,7 @@ echo "Running cellfinder from the main branch..."
 brainmapper -s $SIGNAL_PATH -b $BACKGROUND_PATH -o ./cellfinder_main -v $RESOLUTION --orientation apl --no-register --no-analyse --no-figures
 
 git -C cellfinder fetch origin pull/$PR_NUMBER/head:$PR_NUMBER-branch
+git -C cellfinder checkout $PR_NUMBER-branch
 
 echo "Reinstalling cellfinder from the PR branch to account for dependency changes"
 pip install ./cellfinder -U
@@ -69,7 +70,7 @@ brainmapper -s $SIGNAL_PATH -b $BACKGROUND_PATH -o ./cellfinder_$PR_NUMBER -v $R
 echo "Comparing the results..."
 python $COMPARISON_SCRIPT $PR_NUMBER
 
-echo "Cleaning up the environment and temporary folder..."
+echo "Cleaning up the environment..."
 conda deactivate
 conda env remove -n cellfinder_comparison -y -q
 

--- a/bash/compare_cellfinder_output.sh
+++ b/bash/compare_cellfinder_output.sh
@@ -42,7 +42,6 @@ if [ -d "cellfinder" ]; then
     echo "cellfinder directory already exists"
     git -C cellfinder pull
     git -C cellfinder checkout main
-    cd ..
 else
     echo "Cloning cellfinder repository..."
     git clone https://github.com/brainglobe/cellfinder.git

--- a/bash/compare_cellfinder_output.sh
+++ b/bash/compare_cellfinder_output.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# This script compares the output of two cellfinder runs.
+# One run is from the main branch and the other is from a feature branch.
+# Creates a fresh environment for each run to ensure no interference.
+# Usage: compare_cellfinder_output.sh [-k] <pr_number> <signal_path> <background_path> <resolution> <validation_script_path>
+# Resolution must be provided as one arg with quotes separated by spaces, e.g. "5 2 2"
+# The -k flag can be used to keep the directory after the script finishes.
+
+set -e
+
+KEEP_DIR=false
+
+# Check if the script is run with the -d flag for dry run
+while getopts "k" flag; do
+  case "${flag}" in
+    k) KEEP_DIR=true ;;
+    *) echo "Usage: $0 [-k] <pr_number> <signal_path> <background_path> <resolution> <validation_script_path"
+       exit 1 ;;
+  esac
+done
+
+PR_NUMBER=${@:$OPTIND:1}
+SIGNAL_PATH=${@:$OPTIND+1:1}
+BACKGROUND_PATH=${@:$OPTIND+2:1}
+RESOLUTION=${@:$OPTIND+3:1}
+VALIDATION_SCRIPT_PATH=${@:$OPTIND+4:1}
+
+if [[ -z "PR_NUMBER" || -z "SIGNAL_PATH" || -z "$BACKGROUND_PATH" || -z "$RESOLUTION" || -z "$VALIDATION_SCRIPT_PATH" ]]; then
+    echo "Usage: $0 [-k] <pr_number> <signal_path> <background_path> <resolution> <validation_script_path>"
+    exit 1
+fi
+
+echo "Comparing cellfinder correctness between main and PR $PR_NUMBER"
+
+echo "Cloning cellfinder repository and setting up environment..."
+# Make a new directory to store the results
+mkdir -p $HOME/.cellfinder_comparison_$PR_NUMBER
+cd $HOME/.cellfinder_comparison_$PR_NUMBER
+
+if [ -d "cellfinder" ]; then
+    echo "cellfinder directory already exists"
+    git -C cellfinder pull
+    git -C cellfinder checkout main
+    cd ..
+else
+    echo "Cloning cellfinder repository..."
+    git clone https://github.com/brainglobe/cellfinder.git
+fi
+
+source ~/.bash_profile
+conda activate
+conda create -n cellfinder_comparison python=3.12 -y
+conda activate cellfinder_comparison
+
+pip install brainglobe-workflows
+pip install ./cellfinder -U
+
+echo "Running cellfinder from the main branch..."
+brainmapper -s $SIGNAL_PATH -b $BACKGROUND_PATH -o ./cellfinder_main -v $RESOLUTION --orientation apl --no-register --no-analyse --no-figures
+
+git -C cellfinder fetch origin pull/$PR_NUMBER/head:$PR_NUMBER-branch
+
+echo "Reinstalling cellfinder from the PR branch to account for dependency changes"
+pip install ./cellfinder -U
+
+echo "Running cellfinder from the PR branch..."
+brainmapper -s $SIGNAL_PATH -b $BACKGROUND_PATH -o ./cellfinder_$PR_NUMBER -v $RESOLUTION --orientation apl --no-register --no-analyse --no-figures
+
+echo "Comparing the results..."
+python $VALIDATION_SCRIPT_PATH $PR_NUMBER
+
+echo "Cleaning up the environment and temporary folder..."
+conda deactivate
+conda env remove -n cellfinder_comparison -y -q
+
+if [ "$KEEP_DIR" = false ]; then
+    cd $HOME
+    echo "Removing the temporary directory..."
+    rm -rf .cellfinder_comparison_$PR_NUMBER
+fi

--- a/bash/compare_cellfinder_output.sh
+++ b/bash/compare_cellfinder_output.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# This script compares the output of two cellfinder runs.
+# This script runs the cellfinder portion of brainmapper twice.
 # One run is from the main branch and the other is from a feature branch.
-# Creates a fresh environment for each run to ensure no interference.
-# Usage: compare_cellfinder_output.sh [-k] <pr_number> <signal_path> <background_path> <resolution> <validation_script_path>
-# Resolution must be provided as one arg with quotes separated by spaces, e.g. "5 2 2"
 # The -k flag can be used to keep the directory after the script finishes.
+# Resolution must be provided as one arg with quotes separated by spaces, e.g. "5 2 2"
+# The comparison script is found at scripts/compare_cellfinder_output.py
+# Usage: compare_cellfinder_output.sh [-k] <pr_number> <signal_path> <background_path> <resolution> [<comparison_script_path>]
 
 set -e
 
@@ -15,7 +15,7 @@ KEEP_DIR=false
 while getopts "k" flag; do
   case "${flag}" in
     k) KEEP_DIR=true ;;
-    *) echo "Usage: $0 [-k] <pr_number> <signal_path> <background_path> <resolution> <validation_script_path"
+    *) echo "Usage: $0 [-k] <pr_number> <signal_path> <background_path> <resolution> <comparison_script_path>"
        exit 1 ;;
   esac
 done
@@ -24,10 +24,10 @@ PR_NUMBER=${@:$OPTIND:1}
 SIGNAL_PATH=${@:$OPTIND+1:1}
 BACKGROUND_PATH=${@:$OPTIND+2:1}
 RESOLUTION=${@:$OPTIND+3:1}
-VALIDATION_SCRIPT_PATH=${@:$OPTIND+4:1}
+COMPARISON_SCRIPT=${@:$OPTIND+4:1}
 
-if [[ -z "PR_NUMBER" || -z "SIGNAL_PATH" || -z "$BACKGROUND_PATH" || -z "$RESOLUTION" || -z "$VALIDATION_SCRIPT_PATH" ]]; then
-    echo "Usage: $0 [-k] <pr_number> <signal_path> <background_path> <resolution> <validation_script_path>"
+if [[ -z "$PR_NUMBER" || -z "$SIGNAL_PATH" || -z "$BACKGROUND_PATH" || -z "$RESOLUTION" || -z "$COMPARISON_SCRIPT" ]]; then
+    echo "Usage: $0 [-k] <pr_number> <signal_path> <background_path> <resolution> <comparison_script_path>"
     exit 1
 fi
 
@@ -68,7 +68,7 @@ echo "Running cellfinder from the PR branch..."
 brainmapper -s $SIGNAL_PATH -b $BACKGROUND_PATH -o ./cellfinder_$PR_NUMBER -v $RESOLUTION --orientation apl --no-register --no-analyse --no-figures
 
 echo "Comparing the results..."
-python $VALIDATION_SCRIPT_PATH $PR_NUMBER
+python $COMPARISON_SCRIPT $PR_NUMBER
 
 echo "Cleaning up the environment and temporary folder..."
 conda deactivate

--- a/python/compare_cellfinder_outputs.py
+++ b/python/compare_cellfinder_outputs.py
@@ -1,0 +1,35 @@
+import sys
+
+from brainglobe_utils.cells.cells import match_cells
+from brainglobe_utils.IO.cells import get_cells, save_cells
+from pathlib import Path
+
+if __name__ == "__main__":
+    pr_number = Path(sys.argv[1])
+    working_dir = Path.home() / f".cellfinder_comparison_{pr_number}"
+    cells_main_path = working_dir / "cellfinder_main" / "points" / "cell_classification.xml"
+    cells_pr_path = working_dir / f"cellfinder_{pr_number}" / "points" / "cell_classification.xml"
+
+    cells_main = get_cells(str(cells_main_path))
+    cells_pr = get_cells(str(cells_pr_path))
+
+    only_main, matched_cells, only_vis = match_cells(cells_main, cells_pr, threshold=0.1)
+
+
+    print(f"Number of cells only found with cellfinder from main: {len(only_main)}")
+    print(f"Number of cells only found with cellfinder from {pr_number}: {len(only_vis)}")
+    print(f"Number of matched cells: {len(matched_cells)}")
+    print(f"Matching proportion: {float(len(matched_cells)) / max(len(cells_main), len(cells_pr))}")
+
+    only_main_cells = []
+    for cell_index in only_main:
+        only_main_cells.append(cells_main[cell_index])
+
+    only_vis_cells = []
+    for cell_index in only_vis:
+        only_vis_cells.append(cells_pr[cell_index])
+
+    if len(only_main_cells) != 0:
+        save_cells(only_main_cells, str(working_dir / "only_main.xml"))
+    if len(only_vis_cells) != 0:
+        save_cells(only_vis_cells, str(working_dir / "only_vis.xml"))


### PR DESCRIPTION
This bash scripts creates a temp directory and inside that directory clones the cellfinder repo.

A temporary conda environment is created with python=3.12.

`brainglobe-workflows` is installed first to enable `brainmapper`. 
`cellfinder` is installed from the cloned directory.
`brainmapper` is run with the --no-registration, --no-analyse, and --no-figures flags.

It then checks out the PR branch, installs `cellfinder` again, and runs `brainmapper` with the same settings.

The outputs of both runs are saved in the temp directory created above.

A python validation scripts is then called to compare the results.

The temporary conda environment and temp directory are deleted after every run. If you want to keep the temp directory use the -k flag prior to the other positional arguments.