### PR TITLE
Add scripts to test GPUs in the cluster

### DIFF
--- a/bash/test_all_GPUs_in_cluster/README.md
+++ b/bash/test_all_GPUs_in_cluster/README.md
@@ -1,0 +1,15 @@
+# GPU Node Runner Scripts
+
+Generalized scripts for running arbitrary Python scripts across all available GPU nodes in an HPC cluster.
+
+
+## Usage
+
+```bash
+bash scripts/run_on_all_gpu_nodes.sh your_script.py my_env miniconda/24.1
+```
+
+**Arguments:**
+- `python_script` (required): Path to Python script to run
+- `conda_env` (required): Conda environment name 
+- `module_name` (optional): Module to load (default: `miniconda`)

--- a/bash/test_all_GPUs_in_cluster/example_gpu_test.py
+++ b/bash/test_all_GPUs_in_cluster/example_gpu_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Example test script for use with gpu_node_runner.sh
+This can be used as a template for your own GPU testing scripts.
+"""
+import sys
+import socket
+
+def main():
+    print('='*60)
+    print('EXAMPLE GPU TEST SCRIPT')
+    print('='*60)
+    print('Python executable:', sys.executable)
+    print('Hostname:', socket.gethostname())
+    print()
+
+    # Test 1: PyTorch CUDA check
+    print('[TEST 1] PyTorch import and CUDA check')
+    try:
+        import torch
+        print('  ✓ torch version:', torch.__version__)
+        print('  ✓ CUDA available:', torch.cuda.is_available())
+        if torch.cuda.is_available():
+            print('  ✓ CUDA version:', torch.version.cuda)
+            print('  ✓ GPU:', torch.cuda.get_device_name(0))
+            print('  ✓ GPU memory:', f"{torch.cuda.get_device_properties(0).total_memory / 1e9:.1f}GB")
+    except Exception as e:
+        print('  ✗ FAILED:', repr(e))
+        return 1
+
+    print()
+    print('='*60)
+    print('ALL TESTS PASSED ✓')
+    print('='*60)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bash/test_all_GPUs_in_cluster/gpu_node_runner.sh
+++ b/bash/test_all_GPUs_in_cluster/gpu_node_runner.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SBATCH directives - run arbitrary Python script on GPU node
+#SBATCH --job-name=gpu_python_runner
+#SBATCH --output=logs/gpu_python_runner_%j.out
+#SBATCH --error=logs/gpu_python_runner_%j.err
+#SBATCH --time=00:05:00
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=8G
+
+set -euo pipefail
+
+# Check if Python script path is provided
+if [ "$#" -lt 1 ]; then
+    echo "ERROR: No Python script provided"
+    echo "Usage: $0 <python_script.py> [conda_env] [module_name]"
+    exit 1
+fi
+
+PYTHON_SCRIPT="$1"
+CONDA_ENV="$2"
+MODULE_NAME="${3:-miniconda}"
+
+# Verify the Python script exists
+if [ ! -f "${PYTHON_SCRIPT}" ]; then
+    echo "ERROR: Python script not found: ${PYTHON_SCRIPT}"
+    exit 1
+fi
+
+echo "Starting Python script execution on GPU node"
+echo "Hostname: $(hostname)"
+echo "Date: $(date --iso-8601=seconds)"
+echo "Python script: ${PYTHON_SCRIPT}"
+echo "Conda environment: ${CONDA_ENV}"
+echo "Module: ${MODULE_NAME}"
+echo ""
+
+# Ensure modules system is available
+source /etc/profile.d/modules.sh
+
+echo "Loading module: ${MODULE_NAME}..."
+module load "${MODULE_NAME}" 
+
+echo "Activating conda environment: ${CONDA_ENV}"
+conda activate "${CONDA_ENV}"
+
+echo "Python version:" $(python -V 2>&1)
+echo ""
+
+echo "nvidia-smi output (brief):" 
+if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader 2>/dev/null || echo "nvidia-smi query failed"
+else
+    echo "nvidia-smi not available"
+fi
+
+echo ""
+echo "=========================================="
+echo "Running Python script: ${PYTHON_SCRIPT}"
+echo "=========================================="
+echo ""
+
+# Execute the provided Python script
+python "${PYTHON_SCRIPT}"
+
+EXIT_CODE=$?
+
+echo ""
+echo "=========================================="
+if [ ${EXIT_CODE} -eq 0 ]; then
+    echo "Script completed successfully ✓"
+else
+    echo "Script failed with exit code: ${EXIT_CODE}"
+fi
+echo "=========================================="
+
+exit ${EXIT_CODE}

--- a/bash/test_all_GPUs_in_cluster/run_on_all_gpu_nodes.sh
+++ b/bash/test_all_GPUs_in_cluster/run_on_all_gpu_nodes.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Wrapper script to submit Python script execution to ALL GPU nodes
+# Tests across all available GPU partitions (gpu, gpu_lowp, a100)
+
+set -euo pipefail
+
+# Check arguments
+if [ "$#" -lt 1 ]; then
+    echo "ERROR: No Python script provided"
+    echo ""
+    echo "Usage: $0 <python_script.py> [conda_env] [module_name]"
+    echo ""
+    echo "Arguments:"
+    echo "  python_script.py  - Path to Python script to run on GPU nodes"
+    echo "  conda_env         - Conda environment name"
+    echo "  module_name       - Module to load before conda (default: miniconda)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 test_pytorch.py"
+    echo "  $0 test_pytorch.py my_env"
+    echo "  $0 benchmark.py my_env miniconda/24.1"
+    exit 1
+fi
+
+PYTHON_SCRIPT="$1"
+CONDA_ENV="$2"
+MODULE_NAME="${3:-miniconda}"
+
+# Generate job prefix from script name (remove .py extension and path)
+SCRIPT_BASENAME=$(basename "${PYTHON_SCRIPT}" .py)
+JOB_PREFIX="${SCRIPT_BASENAME}"
+
+# Verify the Python script exists
+if [ ! -f "${PYTHON_SCRIPT}" ]; then
+    echo "ERROR: Python script not found: ${PYTHON_SCRIPT}"
+    exit 1
+fi
+
+# Get absolute path for the script
+PYTHON_SCRIPT_ABS=$(readlink -f "${PYTHON_SCRIPT}")
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SBATCH_SCRIPT="${SCRIPT_DIR}/gpu_node_runner.sh"
+
+if [ ! -f "${SBATCH_SCRIPT}" ]; then
+    echo "ERROR: sbatch script not found: ${SBATCH_SCRIPT}"
+    exit 1
+fi
+
+# Create logs directory if it doesn't exist
+LOGS_DIR="${SCRIPT_DIR}/../logs"
+mkdir -p "${LOGS_DIR}"
+
+echo "=========================================="
+echo "GPU Node Python Script Runner"
+echo "=========================================="
+echo "Python script: ${PYTHON_SCRIPT_ABS}"
+echo "Conda environment: ${CONDA_ENV}"
+echo "Module: ${MODULE_NAME}"
+echo "Job name: ${JOB_PREFIX}"
+echo ""
+
+echo "Discovering GPU nodes from all partitions (gpu, gpu_lowp, a100)..."
+
+# Get all unique GPU nodes from gpu, gpu_lowp, and a100 partitions
+GPU_NODES=$(sinfo -N -o "%N %G %P %T" | \
+    grep "^gpu-" | \
+    grep -v "down" | \
+    grep -E "(gpu|gpu_lowp|a100)" | \
+    awk '{print $1}' | \
+    sort -u)
+
+if [ -z "${GPU_NODES}" ]; then
+    echo "ERROR: No GPU nodes found"
+    exit 1
+fi
+
+NODE_COUNT=$(echo "${GPU_NODES}" | wc -l)
+echo "Found ${NODE_COUNT} unique GPU nodes to test"
+echo ""
+
+# Track submitted jobs and failed nodes
+SUBMITTED_JOBS=()
+FAILED_NODES=()
+
+# Get partition for each node
+declare -A NODE_PARTITION
+
+set +u  # Disable unbound variable check for associative array operations
+while read -r line; do
+    node=$(echo "$line" | awk '{print $1}')
+    partition=$(echo "$line" | awk '{print $3}')
+    # Prefer specific partitions over generic 'gpu'
+    if [[ "$partition" == "a100" ]] || [[ "$partition" == "gpu_lowp" ]]; then
+        NODE_PARTITION[$node]=$partition
+    elif [[ -z "${NODE_PARTITION[$node]:-}" ]]; then
+        NODE_PARTITION[$node]=$partition
+    fi
+done < <(sinfo -N -o "%N %G %P %T" | grep "^gpu-" | grep -v "down" | grep -E "(gpu|gpu_lowp|a100)")
+set -u  # Re-enable
+
+# Submit one job per GPU node with appropriate partition
+set +u  # Temporarily disable unbound variable check for associative array
+for node in ${GPU_NODES}; do
+    # Get partition for this node, default to gpu if not set
+    partition="${NODE_PARTITION[$node]:-gpu}"
+    set -u  # Re-enable
+    
+    echo "Submitting job to node: ${node} (partition: ${partition})"
+    
+    # Submit with explicit nodelist and partition, passing script and environment
+    JOB_OUTPUT="${LOGS_DIR}/${JOB_PREFIX}_${node}.out"
+    JOB_ERROR="${LOGS_DIR}/${JOB_PREFIX}_${node}.err"
+    
+    JOB_RESULT=$(sbatch \
+        --partition="${partition}" \
+        --nodelist="${node}" \
+        --output="${JOB_OUTPUT}" \
+        --error="${JOB_ERROR}" \
+        --job-name="${JOB_PREFIX}_${node}" \
+        "${SBATCH_SCRIPT}" "${PYTHON_SCRIPT_ABS}" "${CONDA_ENV}" "${MODULE_NAME}" 2>&1)
+    
+    if echo "${JOB_RESULT}" | grep -q "Submitted batch job"; then
+        JOB_ID=$(echo "${JOB_RESULT}" | awk '{print $NF}')
+        SUBMITTED_JOBS+=("${JOB_ID}")
+        echo "  -> Job ID: ${JOB_ID}"
+    else
+        FAILED_NODES+=("${node}")
+        echo "  -> FAILED: ${JOB_RESULT}"
+    fi
+done
+
+echo ""
+echo "=========================================="
+echo "Submitted ${#SUBMITTED_JOBS[@]} jobs successfully"
+if [ ${#FAILED_NODES[@]} -gt 0 ]; then
+    echo "Failed to submit to ${#FAILED_NODES[@]} nodes: ${FAILED_NODES[*]}"
+fi
+echo "Job IDs: ${SUBMITTED_JOBS[*]}"
+echo ""
+echo "Output files will be in: ${LOGS_DIR}/${JOB_PREFIX}_<node>.out"
+echo "Error files will be in: ${LOGS_DIR}/${JOB_PREFIX}_<node>.err"
+echo ""
+echo "To monitor job status:"
+echo "  squeue -u \$USER | grep ${JOB_PREFIX}"
+echo "=========================================="


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This pull request introduces a set of generalized scripts for running arbitrary Python scripts across all available GPU nodes in an HPC cluster. You can specify which conda environment to use and with which module to test your script.

There are a few hardcoded parameters related to our cluster, as the name of the partitions.

I originally made these scripts to test the usage of Cellpose across GPUs. I see sometimes erratic behavior across GPUs, it is useful to know which ones to exclude when submitting an array of SLURM jobs.

**What does this PR do?**
* Added `gpu_node_runner.sh`, a robust SBATCH script for running Python scripts on a single GPU node. 
* Added `run_on_all_gpu_nodes.sh`, a wrapper script that discovers all available GPU nodes across multiple partitions and submits jobs to each node, tracking job submissions and failures.
* Created `README.md` with usage instructions, argument descriptions.
* Added `example_gpu_test.py`, a template Python script that performs basic GPU checks using PyTorch, intended for use with the runner scripts.

## How has this PR been tested?
Run in our cluster.

## Is this a breaking change?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
