### PR TITLE
Update-fetch-citations-counts

### DIFF
--- a/python/fetch_citations_counts.py
+++ b/python/fetch_citations_counts.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pyalex",
+#     "pandas",
+# ]
+# ///
+
 """Fetch citation counts for a list of tools from OpenAlex and save to CSV.
 
 The input is a dictionary mapping each tool to a a list of DOIs

--- a/python/fetch_citations_counts.py
+++ b/python/fetch_citations_counts.py
@@ -51,10 +51,6 @@ TOOLS_TO_PUBS = {
     "idtracker": [
         "https://doi.org/10.1038/s41592-018-0295-5",
     ],
-    "OpenPose": [
-        "https://doi.org/10.48550/arXiv.1812.08008",  # main paper
-        "https://doi.org/10.48550/arXiv.1704.07809",    # hand and face models
-    ],
     "FastTrack": [
         "https://doi.org/10.1371/journal.pcbi.1008697",   # main paper
     ],
@@ -72,6 +68,9 @@ TOOLS_TO_PUBS = {
     "OptiFlex": [
         "https://doi.org/10.3389/fncel.2021.621252",  # main paper
         "https://doi.org/10.1101/2020.04.04.025494",  # preprint
+    ],
+    "OCTRON": [
+        "https://doi.org/10.64898/2025.12.20.695663",  # preprint
     ],
 }
 


### PR DESCRIPTION
Updates the script for fetching citations to markerless animal motion tracking tools.

- Removes OpenPose (because it's primarily for human use) and adds OCTRON
- Added inline script metadata so the script can be run easily with `uv run script.py` without needing to create an env
